### PR TITLE
Fix SSR safety for FPS meter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@overengineering/fps-meter",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- guard device pixel ratio and animation loop access behind browser checks so SSR no longer crashes
- reuse the memoized pixel ratio for all canvas sizing and average FPS rendering
- bump package version to 0.2.4 after rebuilding the dist output

## Testing
- pnpm build